### PR TITLE
update quickstart - center method - to use fill

### DIFF
--- a/src/quickstart/snippets/main.rs
+++ b/src/quickstart/snippets/main.rs
@@ -56,8 +56,8 @@ impl Counter {
         ];
         // ANCHOR_END: row
         widget::container(row)
-            .center_x()
-            .center_y()
+            .center_x(iced::widget::Fill)
+            .center_y(iced::widget::Fill)
             .width(iced::Length::Fill)
             .height(iced::Length::Fill)
             .into()


### PR DESCRIPTION
0.13 has an example where center takes 1 argument:

`use iced::widget::{column, container, row};
use iced::{Fill, Element};

fn view(state: &State) -> Element<Message> {
    container(
        column![
            "Top",
            row!["Left", "Right"].spacing(10),
            "Bottom"
        ]
        .spacing(10)
    )
    .padding(10)
    .center_x(Fill)
    .center_y(Fill)
    .into()
}`