### PR TITLE
Add `iced_dialog` in „Other Crates” and under the FAQ

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -54,6 +54,7 @@ A list of other crates that you might find helpful while creating a gui with ice
 - [iced_divider](https://github.com/icedpygui/iced_divider): "An Iced widget used to change the size of adjacent containers using the mouse horizontally or vertically."
 - [modav_widgets](https://github.com/EmmanuelDodoo/modav_widgets/tree/main): custom widgets and experimental UI components for the [modav project](https://github.com/EmmanuelDodoo/modav) (very nice table and tree view widget)
 - [iced_toasts](https://crates.io/crates/iced_toasts) add-on crate to provides a simple way to add toast notifications
+- [iced_dialog](https://github.com/pml68/iced_dialog/tree/master) provides a native, customizable message dialog widget
 - [iced_audio](https://github.com/iced-rs/iced_audio): Helpful widgets for audio applications (although unmaintained, and still on iced 0.9 and pretty out of date)
 
 ## Contribution

--- a/src/faq.md
+++ b/src/faq.md
@@ -7,7 +7,7 @@ For IOS, there is [this repository](https://github.com/iced-rs/ios-examples), bu
 
 ## Is there an easy way to create pop-ups?
 
-Iced has no built in way for pop-ups such as error, ok/cancel and file dialog popups. Although you could build them by creating multiple windows, this can be a bit complicated at the beginning. A lot of people simply use [`rfd`](https://docs.rs/rfd/latest/rfd/index.html) for that use case, which works great.
+Iced has no built in way for pop-ups such as error, ok/cancel and file dialog popups. Although you could build them by creating multiple windows, this can be a bit complicated at the beginning. A lot of people simply use [`rfd`](https://docs.rs/rfd/latest/rfd/index.html) for that use case, which works great, but has a GTK3 runtime dependency on Linux for its `MessageDialog`. Another option for message dialogs is [`iced_dialog`](https://iced-dialog.pml68.dev/iced_dialog/index.html), which provides an iced „native” implementation with no extra dependencies.
 
 ## How can I run stuff in the background / multithreaded / async?
 


### PR DESCRIPTION
Also, the link under „Other Crates” currently points to the master branch of `iced_dialog`, which is for `iced-rs/iced#master`. Should I change it to the `0.13` branch?