### PR TITLE
Fix `trunk` link in `wasm.md`

### DIFF
--- a/src/wasm/wasm.md
+++ b/src/wasm/wasm.md
@@ -19,7 +19,7 @@ cargo build --target wasm32-unknown-unknown
 ```
 
 ### Install Trunk
-We will use [trunk](https://trunkrs.dev/) for building and serving the web page. For that, we need to install trunk via cargo:
+We will use [trunk]([https://trunkrs.dev/](https://trunk-rs.github.io/trunk/) for building and serving the web page. For that, we need to install trunk via cargo:
 ```
 cargo install --locked trunk
 ```

--- a/src/wasm/wasm.md
+++ b/src/wasm/wasm.md
@@ -19,7 +19,7 @@ cargo build --target wasm32-unknown-unknown
 ```
 
 ### Install Trunk
-We will use [https://trunkrs.dev/](https://trunk-rs.github.io/trunk/) for building and serving the web page. For that, we need to install trunk via cargo:
+We will use [trunk](https://trunk-rs.github.io/trunk/) for building and serving the web page. For that, we need to install trunk via cargo:
 ```
 cargo install --locked trunk
 ```

--- a/src/wasm/wasm.md
+++ b/src/wasm/wasm.md
@@ -19,7 +19,7 @@ cargo build --target wasm32-unknown-unknown
 ```
 
 ### Install Trunk
-We will use [trunk]([https://trunkrs.dev/](https://trunk-rs.github.io/trunk/) for building and serving the web page. For that, we need to install trunk via cargo:
+We will use [https://trunkrs.dev/](https://trunk-rs.github.io/trunk/) for building and serving the web page. For that, we need to install trunk via cargo:
 ```
 cargo install --locked trunk
 ```


### PR DESCRIPTION
The provided link was leading to some gambling site, so not even close to what it should be pointed at.
The correct link would be [https://trunk-rs.github.io/trunk/](https://trunk-rs.github.io/trunk/), as shown on [`trunk`'s official github repository page](https://github.com/trunk-rs/trunk).